### PR TITLE
Arabic Support

### DIFF
--- a/lib/client/language_tool_client.dart
+++ b/lib/client/language_tool_client.dart
@@ -38,7 +38,7 @@ class LanguageToolClient {
     );
 
     final languageToolAnswer = LanguageToolRaw.fromJson(
-			json.decode(utf8.decode(result.bodyBytes)) as Map<String, dynamic>,
+      json.decode(utf8.decode(result.bodyBytes)) as Map<String, dynamic>,
     );
 
     return _parseRawAnswer(languageToolAnswer);

--- a/lib/client/language_tool_client.dart
+++ b/lib/client/language_tool_client.dart
@@ -38,7 +38,6 @@ class LanguageToolClient {
     );
 
     final languageToolAnswer = LanguageToolRaw.fromJson(
-      //json.decode(result.body) as Map<String, dynamic>,
 			json.decode(utf8.decode(result.bodyBytes)) as Map<String, dynamic>,
     );
 

--- a/lib/client/language_tool_client.dart
+++ b/lib/client/language_tool_client.dart
@@ -38,7 +38,8 @@ class LanguageToolClient {
     );
 
     final languageToolAnswer = LanguageToolRaw.fromJson(
-      json.decode(result.body) as Map<String, dynamic>,
+      //json.decode(result.body) as Map<String, dynamic>,
+			json.decode(utf8.decode(result.bodyBytes)) as Map<String, dynamic>,
     );
 
     return _parseRawAnswer(languageToolAnswer);

--- a/lib/presentation/language_tool_text_field.dart
+++ b/lib/presentation/language_tool_text_field.dart
@@ -92,6 +92,8 @@ class _LanguageToolTextFieldState extends State<LanguageToolTextField> {
           padding: const EdgeInsets.all(_padding),
           child: Center(
             child: TextField(
+							 textAlign: TextAlign.right,
+							textDirection: TextDirection.rtl,
               focusNode: _focusNode,
               controller: widget.controller,
               scrollController: _scrollController,

--- a/lib/presentation/language_tool_text_field.dart
+++ b/lib/presentation/language_tool_text_field.dart
@@ -32,6 +32,13 @@ class LanguageToolTextField extends StatefulWidget {
   /// ```language``` = 'auto' by default.
   final String language;
 
+  /// Determine text alignment
+  /// textAlign = [TextAlign.start] by default.
+  final TextAlign textAlign;
+
+  /// Determine text Direction
+  final TextDirection? textDirection;
+
   /// Creates a widget that checks grammar errors.
   const LanguageToolTextField({
     required this.controller,
@@ -42,8 +49,8 @@ class LanguageToolTextField extends StatefulWidget {
     this.maxLines = 1,
     this.minLines,
     this.expands = false,
-		this.textAlign = TextAlign.start,
-		this.textDirection,
+    this.textAlign = TextAlign.start,
+    this.textDirection,
     super.key,
   });
 
@@ -94,8 +101,8 @@ class _LanguageToolTextFieldState extends State<LanguageToolTextField> {
           padding: const EdgeInsets.all(_padding),
           child: Center(
             child: TextField(
-							 textAlign: widget.textAlign,
-							textDirection: widget.textDirection,
+              textAlign: widget.textAlign,
+              textDirection: widget.textDirection,
               focusNode: _focusNode,
               controller: widget.controller,
               scrollController: _scrollController,

--- a/lib/presentation/language_tool_text_field.dart
+++ b/lib/presentation/language_tool_text_field.dart
@@ -42,6 +42,8 @@ class LanguageToolTextField extends StatefulWidget {
     this.maxLines = 1,
     this.minLines,
     this.expands = false,
+		this.textAlign = TextAlign.right,
+		this.textDirection = TextDirection.rtl,
     super.key,
   });
 
@@ -92,8 +94,8 @@ class _LanguageToolTextFieldState extends State<LanguageToolTextField> {
           padding: const EdgeInsets.all(_padding),
           child: Center(
             child: TextField(
-							 textAlign: TextAlign.right,
-							textDirection: TextDirection.rtl,
+							 textAlign: widget.textAlign,
+							textDirection: widget.textDirection,
               focusNode: _focusNode,
               controller: widget.controller,
               scrollController: _scrollController,

--- a/lib/presentation/language_tool_text_field.dart
+++ b/lib/presentation/language_tool_text_field.dart
@@ -42,8 +42,8 @@ class LanguageToolTextField extends StatefulWidget {
     this.maxLines = 1,
     this.minLines,
     this.expands = false,
-		this.textAlign = TextAlign.right,
-		this.textDirection = TextDirection.rtl,
+		this.textAlign = TextAlign.start,
+		this.textDirection,
     super.key,
   });
 


### PR DESCRIPTION
This fork supports Arabic LanguageToolTextField, with properties:
1- Support Arabic symbols. Showing correctly.
2- Make LanguageToolTextField right to left alignment possible.