### PR TITLE
Fix Mistake Popup visibility on dark mode #82

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ migrate_working_dir/
 .dart_tool/
 .packages
 build/
+/.flutter-plugins-dependencies
+/example/.flutter-plugins-dependencies

--- a/lib/src/utils/mistake_popup.dart
+++ b/lib/src/utils/mistake_popup.dart
@@ -113,6 +113,8 @@ class LanguageToolMistakePopup extends StatelessWidget {
 
     final availableSpace = _calculateAvailableSpace(context);
 
+    final colorScheme = Theme.of(context).colorScheme;
+
     return PointerInterceptor(
       child: ConstrainedBox(
         constraints: BoxConstraints(
@@ -125,9 +127,14 @@ class LanguageToolMistakePopup extends StatelessWidget {
             vertical: verticalMargin,
           ),
           decoration: BoxDecoration(
-            color: const Color.fromRGBO(241, 243, 248, 1.0),
+            color: colorScheme.surface.withValues(alpha: 0.9),
             borderRadius: BorderRadius.circular(_borderRadius),
-            boxShadow: const [BoxShadow(color: Colors.grey, blurRadius: 8)],
+            boxShadow: [
+              BoxShadow(
+                color: colorScheme.onSurface.withValues(alpha: 0.5),
+                blurRadius: 8,
+              ),
+            ],
           ),
           padding: const EdgeInsets.only(
             top: 8,
@@ -180,7 +187,7 @@ class LanguageToolMistakePopup extends StatelessWidget {
                   margin: const EdgeInsets.only(top: 8),
                   padding: const EdgeInsets.all(padding),
                   decoration: BoxDecoration(
-                    color: Colors.white,
+                    color: colorScheme.surface,
                     borderRadius: BorderRadius.circular(_borderRadius),
                   ),
                   child: SingleChildScrollView(
@@ -194,7 +201,8 @@ class LanguageToolMistakePopup extends StatelessWidget {
                           child: Text(
                             mistake.type.name.capitalize(),
                             style: TextStyle(
-                              color: Colors.grey.shade700,
+                              color:
+                                  colorScheme.onSurface.withValues(alpha: 0.7),
                               fontSize: _mistakeNameFontSize,
                               fontWeight: FontWeight.w600,
                               letterSpacing: _titleLetterSpacing,


### PR DESCRIPTION
This commit aims to fix and improve accessibility when the app is in Dark mode;

Light Mode:

<img src="https://github.com/user-attachments/assets/14724fdd-f967-4812-b42c-c67d89c5532f" width="300" alt="Light Mode Image">

Dark Mode:

<img src="https://github.com/user-attachments/assets/67056be3-b6b2-40b6-96e2-f7fa82b42ddc" width="300" alt="Dark Mode Image">