### PR TITLE
docs: rewrite changelog for the 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,18 @@
 ### BREAKING CHANGES
 
 - `build!`: require Flutter 3.27.0 or higher and Dart 3.0.0 or higher ([#91](https://github.com/solid-software/languagetool_textfield/pull/91))
-- `refactor!`: `LanguageToolTextField` now extends Flutter's `TextField` instead of `StatefulWidget` ([#90](https://github.com/solid-software/languagetool_textfield/pull/90))
-- `refactor!`: rename `LanguageToolTextField` parameters to match `TextField`'s naming ([#90](https://github.com/solid-software/languagetool_textfield/pull/90))
+- `LanguageToolTextField` now extends Flutter's `TextField` instead of `StatefulWidget` ([#90](https://github.com/solid-software/languagetool_textfield/pull/90))
+- rename `LanguageToolTextField` parameters to match `TextField`'s naming ([#90](https://github.com/solid-software/languagetool_textfield/pull/90))
   - `autoFocus` -> `autofocus`
   - `onTextChange` -> `onChanged`
   - `onTextSubmitted` -> `onSubmitted`
-- `refactor!`: rename language check services and move them to `wrappers/` ([#93](https://github.com/solid-software/languagetool_textfield/pull/93), [9157f8c](https://github.com/solid-software/languagetool_textfield/commit/9157f8c39b0defe6c3dda6d6e2945980fad67594))
+- rename language check services and move them to `wrappers/` ([#93](https://github.com/solid-software/languagetool_textfield/pull/93), [9157f8c](https://github.com/solid-software/languagetool_textfield/commit/9157f8c39b0defe6c3dda6d6e2945980fad67594))
   - `LangToolService` -> `LanguageToolService`
   - `DebounceLangToolService` -> `DebounceLanguageCheckService`
   - `ThrottlingLangToolService` -> `ThrottlingLanguageCheckService`
-- `refactor!`: hide `baseService`, `debouncing` and `throttling` fields from the debouncing and throttling wrappers ([#93](https://github.com/solid-software/languagetool_textfield/pull/93), [9157f8c](https://github.com/solid-software/languagetool_textfield/commit/9157f8c39b0defe6c3dda6d6e2945980fad67594))
-- `refactor!`: remove `delayType` and `delay` fields from `LanguageToolController`; they remain constructor parameters ([#93](https://github.com/solid-software/languagetool_textfield/pull/93))
-- `feat!`: `LanguageCheckService` implementations must now provide a `language` getter and setter ([#93](https://github.com/solid-software/languagetool_textfield/pull/93), [8f2b230](https://github.com/solid-software/languagetool_textfield/commit/8f2b230cadf60f2886fc009c396528bbdf1c99ba))
+- hide `baseService`, `debouncing` and `throttling` fields from the debouncing and throttling wrappers ([#93](https://github.com/solid-software/languagetool_textfield/pull/93), [9157f8c](https://github.com/solid-software/languagetool_textfield/commit/9157f8c39b0defe6c3dda6d6e2945980fad67594))
+- remove `delayType` and `delay` fields from `LanguageToolController`; they remain constructor parameters ([#93](https://github.com/solid-software/languagetool_textfield/pull/93))
+- `LanguageCheckService` implementations must now provide a `language` getter and setter ([#93](https://github.com/solid-software/languagetool_textfield/pull/93), [8f2b230](https://github.com/solid-software/languagetool_textfield/commit/8f2b230cadf60f2886fc009c396528bbdf1c99ba))
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,31 @@
-## 1.0.1
-
-- Fix: recheck text on changing language
-- Fixes a bug where changing text programmatically can sometimes throw a RangeError
-- Fixes notifying listeners after async gap when disposed
-
 ## 1.0.0
 
-- BREAKING: require flutter 3.27.0 or higher
-- BREAKING: require dart 3.0.0 or higher
-- BREAKING: rename autoFocus to autofocus to match `TextField`'s naming
-- potentially BREAKING: remove `delayType` and `delay` fields from `LanguageToolController`
-- potentially BREAKING: hide baseService and debouncing/throttling from Debouncing and Throttling LanguageService wrappers
-- potentially BREAKING: rename `DebounceLanguageToolService` to `DebounceLanguageCheckService`
-- potentially BREAKING: rename `ThrottleLanguageToolService` to `ThrottleLanguageCheckService`
-- Support adding words to dictionary through `addWordToDictionary` callback in `LanguageToolMistakePopup`
-- Allow overriding `languageCheckService`
-- Add `isEnabled` to toggle spell check
-- Use default IconButton padding for mistake popup
-- Add missing properties from flutter's `TextField`
+### BREAKING CHANGES
+
+- `build!`: require Flutter 3.27.0 or higher and Dart 3.0.0 or higher ([#91](https://github.com/solid-software/languagetool_textfield/pull/91))
+- `refactor!`: `LanguageToolTextField` now extends Flutter's `TextField` instead of `StatefulWidget` ([#90](https://github.com/solid-software/languagetool_textfield/pull/90))
+- `refactor!`: rename `LanguageToolTextField` parameters to match `TextField`'s naming ([#90](https://github.com/solid-software/languagetool_textfield/pull/90))
+  - `autoFocus` -> `autofocus`
+  - `onTextChange` -> `onChanged`
+  - `onTextSubmitted` -> `onSubmitted`
+- `refactor!`: rename language check services and move them to `wrappers/` ([#93](https://github.com/solid-software/languagetool_textfield/pull/93), [9157f8c](https://github.com/solid-software/languagetool_textfield/commit/9157f8c39b0defe6c3dda6d6e2945980fad67594))
+  - `LangToolService` -> `LanguageToolService`
+  - `DebounceLangToolService` -> `DebounceLanguageCheckService`
+  - `ThrottlingLangToolService` -> `ThrottlingLanguageCheckService`
+- `refactor!`: hide `baseService`, `debouncing` and `throttling` fields from the debouncing and throttling wrappers ([#93](https://github.com/solid-software/languagetool_textfield/pull/93), [9157f8c](https://github.com/solid-software/languagetool_textfield/commit/9157f8c39b0defe6c3dda6d6e2945980fad67594))
+- `refactor!`: remove `delayType` and `delay` fields from `LanguageToolController`; they remain constructor parameters ([#93](https://github.com/solid-software/languagetool_textfield/pull/93))
+- `feat!`: `LanguageCheckService` implementations must now provide a `language` getter and setter ([#93](https://github.com/solid-software/languagetool_textfield/pull/93), [8f2b230](https://github.com/solid-software/languagetool_textfield/commit/8f2b230cadf60f2886fc009c396528bbdf1c99ba))
+
+### New Features
+
+- allow overriding `languageCheckService` on `LanguageToolController` for full control over how text is analyzed ([#93](https://github.com/solid-software/languagetool_textfield/pull/93))
+- add `isEnabled` to toggle spell check ([#92](https://github.com/solid-software/languagetool_textfield/pull/92))
+- support adding words to dictionary through the `addWordToDictionary` callback in `LanguageToolMistakePopup` ([#95](https://github.com/solid-software/languagetool_textfield/pull/95), [9de4a15](https://github.com/solid-software/languagetool_textfield/commit/9de4a153a381959713ef971932afd8cef83a69cc))
+- add `FilteredLanguageCheckService` to drop mistakes matching a custom predicate ([#95](https://github.com/solid-software/languagetool_textfield/pull/95))
+- add `LanguageToolController.recheckText()` to force a recheck without changing the text ([#95](https://github.com/solid-software/languagetool_textfield/pull/95), [9de4a15](https://github.com/solid-software/languagetool_textfield/commit/9de4a153a381959713ef971932afd8cef83a69cc))
+- export `Result` to allow custom `LanguageCheckService` implementations ([#95](https://github.com/solid-software/languagetool_textfield/pull/95))
+- add missing properties from Flutter's `TextField` ([#90](https://github.com/solid-software/languagetool_textfield/pull/90))
   - autofillHints
-  - autofocus
   - buildCounter
   - canRequestFocus
   - clipBehavior
@@ -37,7 +43,6 @@
   - enableSuggestions
   - ignorePointers
   - inputFormatters
-  - key
   - magnifierConfiguration
   - maxLength
   - maxLengthEnforcement
@@ -62,6 +67,16 @@
   - textAlignVertical
   - textCapitalization
   - undoController
+
+### Fixes
+
+- mistake popup is now themed with the app's `ColorScheme`, fixing visibility in dark mode ([#88](https://github.com/solid-software/languagetool_textfield/pull/88))
+- recheck text when the language changes ([#96](https://github.com/solid-software/languagetool_textfield/pull/96), [cae2cba](https://github.com/solid-software/languagetool_textfield/commit/cae2cba337ac9c2973d534159265f072c3a050ea))
+- clear mistakes that fall out of the new text range, fixing a `RangeError` when changing text programmatically ([#97](https://github.com/solid-software/languagetool_textfield/pull/97))
+- prevent notifying listeners after an async gap when the controller is disposed ([#97](https://github.com/solid-software/languagetool_textfield/pull/97))
+- `ThrottlingLanguageCheckService` now discards mistakes with offsets outside the checked text's range ([#95](https://github.com/solid-software/languagetool_textfield/pull/95))
+- avoid setting `scrollOffset` before the scroll controller is attached ([#100](https://github.com/solid-software/languagetool_textfield/pull/100))
+- `style`: use the default `IconButton` padding in the mistake popup ([#95](https://github.com/solid-software/languagetool_textfield/pull/95), [9de4a15](https://github.com/solid-software/languagetool_textfield/commit/9de4a153a381959713ef971932afd8cef83a69cc))
 
 ## 0.1.1
 


### PR DESCRIPTION
## Motivation

`0.1.1` is the last version actually published to pub.dev — `1.0.0` was never released, so the pending `1.0.1` section described changes that no user has ever received. This merges both into a single `1.0.0` entry so the changelog reflects what an upgrading user will actually experience, and prepares the package for release.

## Corrections to previously documented entries

| Entry | Problem |
|---|---|
| Service renames | Named classes that never existed (`DebounceLanguageToolService`, `ThrottleLanguageToolService`). Real renames: `LangToolService` → `LanguageToolService`, `DebounceLangToolService` → `DebounceLanguageCheckService`, `ThrottlingLangToolService` → `ThrottlingLanguageCheckService`. The `LangToolService` rename was missing entirely. |
| `key` in the added-properties list | The constructor already accepted `super.key` in 0.1.1 — never added. |
| `autofocus` in the same list | Only appears "new" due to the case change; it's the `autoFocus` rename, already covered by its own breaking entry. |
| PR #99 (remove duplicate `super.key`) | Net-zero: the duplication was introduced *and* removed within PR #95's own branch history. Dropped. |
| PR #98 (example build files) | Example app only, no `lib/` changes. Dropped. |

## Newly documented changes

These were missing from the changelog altogether:

- `LanguageToolTextField` now extends `TextField` instead of `StatefulWidget` (#90) — the architectural change underpinning the whole property list
- `onTextChange` → `onChanged`, `onTextSubmitted` → `onSubmitted` (#90) — **breaking**, previously undocumented
- `LanguageCheckService` now requires a `language` getter/setter (#93) — **breaking** for anyone implementing the interface
- Dark-mode mistake popup fix (#88)
- `recheckText()`, `Result` export, `FilteredLanguageCheckService`, the throttling offset filter (#95)
- The #96 / #97 / #100 fixes
