### PR TITLE
fix: trigger onChanged when selecting recommended text

### DIFF
--- a/lib/src/core/controllers/language_tool_controller.dart
+++ b/lib/src/core/controllers/language_tool_controller.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:languagetool_textfield/languagetool_textfield.dart';
 import 'package:languagetool_textfield/src/utils/closed_range.dart';
 import 'package:languagetool_textfield/src/utils/keep_latest_response_service.dart';
+import 'package:meta/meta.dart';
 
 /// A TextEditingController with overrides buildTextSpan for building
 /// marked TextSpans with tap recognizer
@@ -35,7 +36,8 @@ class LanguageToolController extends TextEditingController {
   /// Reference to the popup widget
   MistakePopup? popupWidget;
 
-  /// Callback triggered when a mistake is replaced with a suggestion.
+  /// Internal callback used by [LanguageToolTextField] to trigger onChanged.
+  @internal
   ValueChanged<String>? onMistakeFixed;
 
   /// Represents the scroll offset value of the LanguageTool TextField.
@@ -189,15 +191,15 @@ class LanguageToolController extends TextEditingController {
       throw StateError('LanguageToolController is not enabled');
     }
 
-    final mistakes = List<Mistake>.from(_mistakes);
-    mistakes.remove(mistake);
-    _mistakes = mistakes;
+    _mistakes = List<Mistake>.of(_mistakes)..remove(mistake);
     text = text.replaceRange(mistake.offset, mistake.endOffset, replacement);
-    onMistakeFixed?.call(text);
     focusNode?.requestFocus();
-    Future.microtask.call(() {
-      final newOffset = mistake.offset + replacement.length;
-      selection = TextSelection.fromPosition(TextPosition(offset: newOffset));
+
+    Future.microtask(() {
+      selection = TextSelection.collapsed(
+        offset: mistake.offset + replacement.length,
+      );
+      onMistakeFixed?.call(text);
     });
   }
 

--- a/lib/src/core/controllers/language_tool_controller.dart
+++ b/lib/src/core/controllers/language_tool_controller.dart
@@ -35,6 +35,9 @@ class LanguageToolController extends TextEditingController {
   /// Reference to the popup widget
   MistakePopup? popupWidget;
 
+  /// Callback triggered when a mistake is replaced with a suggestion.
+  ValueChanged<String>? onMistakeFixed;
+
   /// Represents the scroll offset value of the LanguageTool TextField.
   double? scrollOffset;
 
@@ -190,6 +193,7 @@ class LanguageToolController extends TextEditingController {
     mistakes.remove(mistake);
     _mistakes = mistakes;
     text = text.replaceRange(mistake.offset, mistake.endOffset, replacement);
+    onMistakeFixed?.call(text);
     focusNode?.requestFocus();
     Future.microtask.call(() {
       final newOffset = mistake.offset + replacement.length;

--- a/lib/src/presentation/language_tool_text_field.dart
+++ b/lib/src/presentation/language_tool_text_field.dart
@@ -114,6 +114,7 @@ class _LanguageToolTextFieldState extends State<LanguageToolTextField> {
     controller.language = widget.language;
     final defaultPopup = MistakePopup(popupRenderer: PopupOverlayRenderer());
     controller.popupWidget = widget.mistakePopup ?? defaultPopup;
+    controller.onMistakeFixed = (text) => widget.onChanged?.call(text);
 
     controller.addListener(_syncScrollPosition);
     _scrollController.addListener(_syncScrollPosition);
@@ -225,6 +226,7 @@ class _LanguageToolTextFieldState extends State<LanguageToolTextField> {
 
   @override
   void dispose() {
+    widget.controller.onMistakeFixed = null;
     widget.controller.removeListener(_syncScrollPosition);
     _scrollController.removeListener(_syncScrollPosition);
     if (widget.focusNode == null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^1.0.0
+  meta: ^1.11.0
   pointer_interceptor: ^0.10.1
   throttling: ^2.0.1
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a callback for detecting when a language mistake has been corrected with a suggestion.
  * Corrected text is now forwarded through the text field’s existing change notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->